### PR TITLE
fix type error when registering custom transitions and/or renderers

### DIFF
--- a/src/Core.d.ts
+++ b/src/Core.d.ts
@@ -26,10 +26,10 @@ export default class Core {
         allowInterruption?: boolean;
         bypassCache?: boolean;
         renderers?: {
-            [x: string]: Renderer;
+            [x: string]: typeof Renderer;
         };
         transitions?: {
-            [x: string]: Transition;
+            [x: string]: typeof Transition;
         };
         reloadJsFilter?: boolean | ((arg0: HTMLElement) => boolean);
     });
@@ -43,12 +43,12 @@ export default class Core {
      */
     cache: Map<string, CacheEntry>;
     renderers: {
-        [x: string]: Renderer;
+        [x: string]: typeof Renderer;
     } | {
         default: typeof Renderer;
     };
     transitions: {
-        [x: string]: Transition;
+        [x: string]: typeof Transition;
     } | {
         default: typeof Transition;
     };

--- a/src/Core.d.ts
+++ b/src/Core.d.ts
@@ -1,7 +1,7 @@
 /**
  * @typedef CacheEntry
  * @type {object}
- * @property {Renderer} renderer
+ * @property {typeof Renderer} renderer
  * @property {Document|Node} page
  * @property {array} scripts
  * @property {boolean} skipCache
@@ -15,8 +15,8 @@ export default class Core {
      * 		removeOldContent?: boolean,
      * 		allowInterruption?: boolean,
      * 		bypassCache?: boolean,
-     * 		renderers?: Object.<string, Renderer>,
-     * 		transitions?: Object.<string, Transition>,
+     * 		renderers?: Object.<string, typeof Renderer>,
+     * 		transitions?: Object.<string, typeof Transition>,
      * 		reloadJsFilter?: boolean|function(HTMLElement): boolean
      * }} parameters
      */
@@ -37,23 +37,19 @@ export default class Core {
     /**
      * @type {CacheEntry|null}
      */
-    currentCacheEntry: CacheEntry | null;
+    currentCacheEntry: CacheEntry;
     /**
      * @type {Map<string, CacheEntry>}
      */
     cache: Map<string, CacheEntry>;
     renderers: {
         [x: string]: typeof Renderer;
-    } | {
-        default: typeof Renderer;
     };
     transitions: {
         [x: string]: typeof Transition;
-    } | {
-        default: typeof Transition;
     };
-    defaultRenderer: Renderer | typeof Renderer;
-    defaultTransition: Transition | typeof Transition;
+    defaultRenderer: typeof Renderer;
+    defaultTransition: typeof Transition;
     wrapper: Element;
     reloadJsFilter: boolean | ((element: HTMLElement) => boolean);
     removeOldContent: boolean;
@@ -193,7 +189,7 @@ export default class Core {
     private createCacheEntry;
 }
 export type CacheEntry = {
-    renderer: Renderer;
+    renderer: typeof Renderer;
     page: Document | Node;
     scripts: any[];
     skipCache: boolean;

--- a/src/Core.js
+++ b/src/Core.js
@@ -9,7 +9,7 @@ const IN_PROGRESS = 'A transition is currently in progress'
 /**
  * @typedef CacheEntry
  * @type {object}
- * @property {Renderer} renderer
+ * @property {typeof Renderer} renderer
  * @property {Document|Node} page
  * @property {array} scripts
  * @property {boolean} skipCache
@@ -36,8 +36,8 @@ export default class Core {
 	 * 		removeOldContent?: boolean,
 	 * 		allowInterruption?: boolean,
 	 * 		bypassCache?: boolean,
-	 * 		renderers?: Object.<string, Renderer>,
-	 * 		transitions?: Object.<string, Transition>,
+	 * 		renderers?: Object.<string, typeof Renderer>,
+	 * 		transitions?: Object.<string, typeof Transition>,
 	 * 		reloadJsFilter?: boolean|function(HTMLElement): boolean
 	 * }} parameters
 	 */


### PR DESCRIPTION
previously - taxi types were expecting an instance of the class yet taxi wants the class itself

<img width="1111" alt="CleanShot 2023-06-01 at 00 12 54@2x" src="https://github.com/craftedbygc/taxi/assets/29142128/46541b88-00dd-4892-a601-c0b13c32df6f">
