### PR TITLE
Add check for whether hash has stayed the same in popstate handler

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -437,11 +437,14 @@ export default class Core {
 	onPopstate = () => {
 		// don't trigger for on-page anchors
 		if (
-			window.location.pathname === this.currentLocation.pathname
-			&& window.location.search === this.currentLocation.search
-			&& !this.isPopping
+			window.location.hash !== this.currentLocation.hash ||
+			(
+				window.location.pathname === this.currentLocation.pathname &&
+				window.location.search === this.currentLocation.search &&
+				!this.isPopping
+			)
 		) {
-			return false
+			return false;
 		}
 
 		if (!this.allowInterruption && (this.isTransitioning || this.isPopping)) {

--- a/src/Core.js
+++ b/src/Core.js
@@ -436,13 +436,16 @@ export default class Core {
 	 */
 	onPopstate = () => {
 		// don't trigger for on-page anchors
+		let windowLocationPathname = window.location.pathname;
+
+		if (window.location.pathname.slice(-1) === '/') {
+			windowLocationPathname = window.location.pathname.slice(0, -1);
+		}
 		if (
-			window.location.hash !== this.currentLocation.hash ||
-			(
-				window.location.pathname === this.currentLocation.pathname &&
-				window.location.search === this.currentLocation.search &&
-				!this.isPopping
-			)
+			(window.location.pathname === this.currentLocation.pathname &&
+			 window.location.search === this.currentLocation.search &&
+			 !this.isPopping) ||
+			(this.currentLocation.pathname === windowLocationPathname)
 		) {
 			return false;
 		}


### PR DESCRIPTION
Howdy team! 

I was having issues with the library still calling transitions on anchor tags that link further down the page. When clicking an anchor tag that had `[target]`, `[href^="#"]`, _and_ `[data-taxi-ignore]` present, the page was still playing the default transition I had defined (OS X Sequoia 15.1, Firefox 132, Chrome 131). I added this check to the `onPopstate` handler and it fixed it for me, so I figured I'd PR in case it's at all useful. 

I figured out there's an issue where if you click a hash anchor while the current page pathname is `/path/url` and the target pathname is `/path/url/`, it will still play the animation. 

Hopefully this isn't too presumptuous, and let me know if you'd like to see any changes! (If it _is_ too presumptuous lmk and I'll promptly don my dunce cap and parade about the town square on a donkey for everyone to mock.)